### PR TITLE
Fix git://github URL to use valid @macccman account

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To run locally:
 
 ## Heroku 10 seconds setup
 
-    git clone git://github.com/stripe/abba.git && cd abba
+    git clone git://github.com/maccman/abba.git && cd abba
     heroku create
     heroku addons:add mongohq:sandbox
     git push heroku master


### PR DESCRIPTION
The git clone URL in the README references the repo as if it was on the stripe org. But as of this writing, it's not there. This edits the instructions to point to the @maccman/abba version of the repo. 
