### PR TITLE
Bug in extend() causes abbaVariant, abbaPersistComplete cookies to have incorrect expiration dates

### DIFF
--- a/app/assets/javascripts/client/index.coffee
+++ b/app/assets/javascripts/client/index.coffee
@@ -48,6 +48,7 @@ extend = (target, args...) ->
   for source in args
     for key, value of source when value?
       target[key] = value
+  return target
 
 # Public
 


### PR DESCRIPTION
'extend', when compiled to js, was returning an array of
arrays rather than an object due to implicit return.

This broke the options sent to setCookie, because the 'expires'
attribute of the returned options object was always undefined,
so the cookie expiration field was never set as
options.expires.toGMTString().

As a result, the abbaVariant and abbaPersistComplete cookies
incorrectly had no expiration date or a received a default expiration
from the browser, rather than the 600 day expiration specified
in the code.

Below is the old `extend`, compiled to js, which incorrectly returns a list:

```
  extend = function() {
    var args, key, source, target, value, _i, _len, _results;
    target = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
    _results = [];
    for (_i = 0, _len = args.length; _i < _len; _i++) {
      source = args[_i];
      _results.push((function() {
    var _results1;
    _results1 = [];
    for (key in source) {
      value = source[key];
      if (value != null) {
        _results1.push(target[key] = value);
      }
    }
    return _results1;
      })());
    }
    return _results;
  };
```

An explicit return compiles correctly:

```
  extend = function() {
    var args, key, source, target, value, _i, _len;
    target = arguments[0], args = 2 <= arguments.length ? __slice.call(arguments, 1) : [];
    for (_i = 0, _len = args.length; _i < _len; _i++) {
      source = args[_i];
      for (key in source) {
    value = source[key];
    if (value != null) {
      target[key] = value;
    }
      }
    }
    return target;
  };
```
