### PR TITLE
Add "expires" option for setting cookie lifetime

### DIFF
--- a/app/assets/javascripts/client/index.coffee
+++ b/app/assets/javascripts/client/index.coffee
@@ -53,8 +53,8 @@ extend = (target, args...) ->
 # Public
 
 class @Abba
-  @endpoint: 'http://localhost:4567'
-  @defaults:
+  endpoint: 'http://localhost:4567'
+  defaults:
     path: '/'
     expires: 600
 


### PR DESCRIPTION
This is useful to avoid accumulating old cookies over time, which impacts request size (the 600 day default is a bit generous for our weekly tests).

Also fixes an issue where defaults weren't getting passed through to `setCookie`.
