### PR TITLE
Specifying explicit Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+ruby '1.9.3'
 source "https://rubygems.org"
 
 gem 'sinatra'


### PR DESCRIPTION
Due to the fact that Heroku's default Ruby version is 2.0.0 and there seems an issue with EventMachine. I'm specify ing a specific version (1.9.3) to make app work on Heroku.
