### PR TITLE
Change default heroku provider from MongoHQ to Mongolab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To run locally:
 
     git clone git://github.com/maccman/abba.git && cd abba
     heroku create
-    heroku addons:add mongohq:sandbox
+    heroku addons:add mongolab:sandbox
     git push heroku master
     heroku open
 

--- a/admin.rb
+++ b/admin.rb
@@ -15,7 +15,7 @@ configure do
   ActiveSupport.escape_html_entities_in_json = true
 
   MongoMapper.setup({
-    'production'  => {'uri' => ENV['MONGOHQ_URL']},
+    'production'  => {'uri' => ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI']},
     'development' => {'uri' => 'mongodb://localhost:27017/abba-development'}
   }, settings.environment.to_s)
 

--- a/app.rb
+++ b/app.rb
@@ -12,7 +12,7 @@ configure do
   ActiveSupport.escape_html_entities_in_json = true
 
   MongoMapper.setup({
-    'production'  => {'uri' => ENV['MONGOHQ_URL']},
+    'production'  => {'uri' => ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI']},
     'development' => {'uri' => 'mongodb://localhost:27017/abba-development'}
   }, settings.environment.to_s)
 


### PR DESCRIPTION
Addon mongohq:sandbox is no longer available on Heroku, but there is a free plan provided by Mongolab (mongolab:sandbox). This change updates both README.md and adds the mongo URI, so the app can be bootstraped on Heroku using the steps provided in documentation.